### PR TITLE
fix: split India into dedicated scraper region (fixes #10)

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        region: [europe, americas, asia-oceania, africa-me]
+        region: [europe, americas, india, asia-oceania, africa-me]
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
-            const regions = ['europe', 'americas', 'asia-oceania', 'africa-me'];
+            const regions = ['europe', 'americas', 'india', 'asia-oceania', 'africa-me'];
             let all = [];
             regions.forEach(r => {
               const file = 'artifacts/tournaments-' + r + '/tournaments-' + r + '.json';

--- a/scripts/scrape.ts
+++ b/scripts/scrape.ts
@@ -346,8 +346,9 @@ const REGION_MAP: Record<string, string[]> = {
     'CAN', 'MEX', 'COL', 'PER', 'CHI', 'VEN', 'ECU', 'URU', 'PAR', 'BOL', 'CUB', 'PUR', 'CRC', 'PAN', 'DOM',
     'TRI', 'JAM', 'BAR', 'GUY', 'SUR', 'HAI', 'NCA', 'ESA', 'HON', 'GUA',
   ],
+  india: ['IND'],
   'asia-oceania': [
-    'IND', 'CHN', 'AUS',
+    'CHN', 'AUS',
     'JPN', 'KOR', 'PHI', 'INA', 'VIE', 'MAS', 'SGP',
     'THA', 'MYA', 'BAN', 'SRI', 'PAK', 'IRI', 'IRQ', 'UAE', 'KSA', 'QAT', 'KUW', 'BRN', 'JOR', 'LBN',
     'SYR', 'UZB', 'KAZ', 'MGL', 'NEP', 'AFG', 'TKM', 'KGZ', 'TJK', 'MDV', 'BRU', 'CAM', 'LAO',


### PR DESCRIPTION
## What does this PR do?
Splits India out of the `asia-oceania` region in the scraper so it gets its own scrape budget instead of starving alongside ~40 other federations.

## Problem
`IND` was bundled into `asia-oceania` in `REGION_MAP` (scripts/scrape.ts), sharing a single 2000-tournament cap with ~40 other federations (CHN, AUS, JPN, KOR, etc). Despite India being one of the largest chess-playing nations on Chess-Results.com with 100+ active/upcoming events, very few Indian tournaments made it through the cap.

## Fix
- Removed `'IND'` from the `asia-oceania` array
- Added a new `india: ['IND']` region with its own dedicated 2000-slot cap
- Wired `india` into the GitHub Actions matrix and the merge step in `.github/workflows/scrape.yml`

## Issue
Closes #10

## Type of change
- [x] Bug fix
- [ ] New scraper source
- [ ] Feature / enhancement
- [ ] Refactor / cleanup

## Checklist
- [x] TypeScript compiles with no errors
- [x] No `any` types introduced
- [x] No credentials or secrets in the code