### PR TITLE
fix: dedupe mobile nav drawer and correct hamburger icon stroke color (fixes #25)

### DIFF
--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -11,6 +11,8 @@ import { useAuth } from "@/lib/AuthContext";
 import Footer from "@/components/Footer";
 import { trackEvent } from "@/lib/track";
 import { useThemePreference } from "@/lib/theme";
+import MobileMenuButton from "@/components/MobileMenuButton";
+import MobileNavDrawer from "@/components/MobileNavDrawer";
 
 const MapContainer = dynamic(
   () => import("react-leaflet").then((m) => m.MapContainer),
@@ -255,45 +257,11 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
   return (
     <>
       {/* Mobile Menu Overlay */}
-      {mobileMenuOpen && (
-        <div
-          className="mobile-overlay"
-          onClick={() => setMobileMenuOpen(false)}
-        >
-          <div
-            className="mobile-drawer"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="mobile-drawer-header">
-              <span className="mobile-drawer-brand font-display">TourneyRadar</span>
-              <button
-                className="mobile-drawer-close"
-                onClick={() => setMobileMenuOpen(false)}
-                aria-label="Close menu"
-              >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                  <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
-              </button>
-            </div>
-
-            <nav className="mobile-drawer-nav">
-              <Link href="/tournaments" onClick={() => setMobileMenuOpen(false)}>
-                Tournaments
-              </Link>
-              {!authLoading && (
-                <Link
-                  href={dashboard.href}
-                  className="mobile-drawer-cta"
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {dashboard.label}
-                </Link>
-              )}
-            </nav>
-          </div>
-        </div>
-      )}
+      <MobileNavDrawer
+        open={mobileMenuOpen}
+        onClose={() => setMobileMenuOpen(false)}
+        dashboard={authLoading ? null : dashboard}
+      />
 
       <section className="hero-bg">
         <nav className="glass">
@@ -309,15 +277,7 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
               )}
             </div>
 
-            <button
-              className="mobile-menu-btn"
-              aria-label="Open menu"
-              onClick={() => setMobileMenuOpen(true)}
-            >
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-                <path d="M4 7h16M4 12h16M4 17h16" stroke="white" strokeWidth="2" strokeLinecap="round" />
-              </svg>
-            </button>
+            <MobileMenuButton onClick={() => setMobileMenuOpen(true)} />
           </div>
         </nav>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -693,6 +693,19 @@
   to { transform: translateX(0); }
 }
 
+.mobile-overlay.closing { animation: fadeOut 0.2s ease-out forwards; }
+.mobile-drawer.closing { animation: slideOut 0.25s ease-out forwards; }
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes slideOut {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+
 /* =============================================
    RESPONSIVE BREAKPOINTS - SINGLE SOURCE OF TRUTH
    ============================================= */

--- a/components/BaseLayout.tsx
+++ b/components/BaseLayout.tsx
@@ -6,6 +6,8 @@ import { useAuth } from "../lib/AuthContext";
 import Footer from "./Footer";
 import ScrollToTop from "./ScrollToTop";
 import ThemeToggle from "./ThemeToggle";
+import MobileMenuButton from "./MobileMenuButton";
+import MobileNavDrawer from "./MobileNavDrawer";
 interface BaseLayoutProps {
   children: React.ReactNode;
   showHero?: boolean;
@@ -37,46 +39,12 @@ export default function BaseLayout({
     <div style={{ background: "var(--background)", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
 
       {/* ========== MOBILE MENU OVERLAY ========== */}
-      {mobileMenuOpen && (
-        <div
-          className="mobile-overlay"
-          onClick={() => setMobileMenuOpen(false)}
-        >
-          <div
-            className="mobile-drawer"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="mobile-drawer-header">
-              <span className="mobile-drawer-brand font-display">TourneyRadar</span>
-              <button
-                className="mobile-drawer-close"
-                onClick={() => setMobileMenuOpen(false)}
-                aria-label="Close menu"
-              >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                  <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
-              </button>
-            </div>
-
-            <nav className="mobile-drawer-nav">
-              <Link href="/tournaments" onClick={() => setMobileMenuOpen(false)}>
-                Tournaments
-              </Link>
-              {!authLoading && (
-                <Link
-                href={dashboard.href}
-                className="mobile-drawer-cta"
-                onClick={() => setMobileMenuOpen(false)}
-                >
-                  {dashboard.label}
-                </Link>
-              )}
-              <ThemeToggle />
-            </nav>
-          </div>
-        </div>
-      )}
+      <MobileNavDrawer
+        open={mobileMenuOpen}
+        onClose={() => setMobileMenuOpen(false)}
+        dashboard={authLoading ? null : dashboard}
+        showThemeToggle
+      />
 
       {showHero ? (
         <section className="hero-bg" style={{ minHeight: "40vh", display: "flex", flexDirection: "column" }}>
@@ -98,15 +66,7 @@ export default function BaseLayout({
                 <ThemeToggle variant="hero" />
               </div>
 
-              <button
-                className="mobile-menu-btn"
-                aria-label="Open menu"
-                onClick={() => setMobileMenuOpen(true)}
-              >
-                <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-                  <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
-              </button>
+              <MobileMenuButton onClick={() => setMobileMenuOpen(true)} />
             </div>
           </nav>
 
@@ -143,17 +103,7 @@ export default function BaseLayout({
 
             <div className="nav-actions">
               <ThemeToggle />
-              <button
-                type="button"
-                className="mobile-menu-btn"
-                aria-label="Open menu"
-                onClick={() => setMobileMenuOpen(true)}
-                style={{ color: "var(--text-primary)" }}
-              >
-                <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
-                  <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
-              </button>
+              <MobileMenuButton onClick={() => setMobileMenuOpen(true)} style={{ color: "var(--text-primary)" }} />
             </div>
 
           </div>

--- a/components/MobileMenuButton.tsx
+++ b/components/MobileMenuButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+interface MobileMenuButtonProps {
+  onClick: () => void;
+  style?: React.CSSProperties;
+}
+
+export default function MobileMenuButton({ onClick, style }: MobileMenuButtonProps) {
+  return (
+    <button type="button" className="mobile-menu-btn" aria-label="Open menu" onClick={onClick} style={style}>
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+        <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    </button>
+  );
+}

--- a/components/MobileNavDrawer.tsx
+++ b/components/MobileNavDrawer.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ThemeToggle from "./ThemeToggle";
+
+export interface DashboardLink {
+  href: string;
+  label: string;
+}
+
+interface MobileNavDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  dashboard: DashboardLink | null;
+  showThemeToggle?: boolean;
+}
+
+const CLOSE_ANIMATION_MS = 250;
+
+export default function MobileNavDrawer({ open, onClose, dashboard, showThemeToggle = false }: MobileNavDrawerProps) {
+  const [rendered, setRendered] = useState(open);
+  const [closing, setClosing] = useState(false);
+  const [prevOpen, setPrevOpen] = useState(open);
+
+  // Adjust state during render in response to the `open` prop changing
+  // (React-sanctioned pattern: https://react.dev/learn/you-might-not-need-an-effect)
+  // rather than in a useEffect, so the exit animation can play before unmount.
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setRendered(true);
+      setClosing(false);
+    } else if (rendered) {
+      setClosing(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!closing) return;
+    const t = setTimeout(() => {
+      setRendered(false);
+      setClosing(false);
+    }, CLOSE_ANIMATION_MS);
+    return () => clearTimeout(t);
+  }, [closing]);
+
+  if (!rendered) return null;
+
+  return (
+    <div className={`mobile-overlay${closing ? " closing" : ""}`} onClick={onClose}>
+      <div className={`mobile-drawer${closing ? " closing" : ""}`} onClick={(e) => e.stopPropagation()}>
+        <div className="mobile-drawer-header">
+          <span className="mobile-drawer-brand font-display">TourneyRadar</span>
+          <button className="mobile-drawer-close" onClick={onClose} aria-label="Close menu">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <nav className="mobile-drawer-nav">
+          <Link href="/tournaments" onClick={onClose}>
+            Tournaments
+          </Link>
+          {dashboard && (
+            <Link href={dashboard.href} className="mobile-drawer-cta" onClick={onClose}>
+              {dashboard.label}
+            </Link>
+          )}
+          {showThemeToggle && <ThemeToggle />}
+        </nav>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #25. HomePageClient's hamburger icon hardcoded `stroke="white"`, making it invisible in some contexts; now uses `currentColor` matching BaseLayout. Extracted the duplicated hamburger button (3 copies) and drawer/overlay markup (2 copies) into shared `MobileMenuButton` and `MobileNavDrawer` components, used by both `BaseLayout` and `HomePageClient`. `MobileNavDrawer` now animates on close (previously unmounted instantly with no exit transition), matching the existing open animation.

Tested locally: hamburger + drawer open/close verified on both the homepage (hero nav) and `/tournaments` (plain nav, with ThemeToggle in drawer) variants. `npm run build` and `npm run lint` pass.

## Type of change

- [x] Bug fix
- [ ] New scraper source
- [ ] Feature / enhancement
- [x] Refactor / cleanup

## For new scrapers

N/A - not a scraper change.

## Checklist

- [x] TypeScript compiles with no errors (`npm run build`)
- [x] No `any` types introduced
- [x] No credentials or secrets in the code