### PR TITLE
chore: add Playwright E2E harness and CI workflow (fixes #17)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,27 @@
+name: E2E
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ yarn-error.log*
 # Claude files
 Claude
 .claude/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "scrape": "npx tsx --env-file=.env.local scripts/scrape.ts",
     "scrape:ci": "npx tsx scripts/scrape.ts",
-    "scrape:region": "npx tsx scripts/scrape.ts"
+    "scrape:region": "npx tsx scripts/scrape.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@next/third-parties": "^16.2.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage loads the tournament map and list", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: /Discover Chess/i })).toBeVisible();
+
+  const map = page.locator("#map .leaflet-container");
+  await expect(map).toBeVisible({ timeout: 20_000 });
+
+  const rows = page.locator(".table-container table tbody tr.table-row");
+  await expect(rows.first()).toBeVisible({ timeout: 20_000 });
+  expect(await rows.count()).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #17. Adds `playwright.config.ts` (`webServer` auto-starts `npm run dev` against `http://localhost:3000` - note `localhost`, not `127.0.0.1`, since Next 16's dev-origin protection blocks cross-origin `/_next/webpack-hmr` requests from `127.0.0.1` by default, which silently breaks client hydration for the dynamically-imported Leaflet map). `tests/e2e/homepage.spec.ts`: smoke test asserting the hero heading, the Leaflet map, and at least one tournament row render. `npm run test:e2e` script added. New `.github/workflows/e2e.yml` (separate from the existing lint-only `ci.yml`), installs Chromium and runs the smoke test on push/PR to main.

`@playwright/test`/`playwright` were already devDependencies (dependabot-bumped, unused) - no new install needed.

Tested locally: `npm run test:e2e` passes against a fresh dev server. `npm run build` and `npm run lint` pass.

## Type of change

- [ ] Bug fix
- [ ] New scraper source
- [x] Feature / enhancement
- [ ] Refactor / cleanup

(closest fit - this adds new test infrastructure; not covered exactly by any category)

## For new scrapers

N/A - not a scraper change.

## Checklist

- [x] TypeScript compiles with no errors (`npm run build`)
- [x] No `any` types introduced
- [x] No credentials or secrets in the code