### PR TITLE
fix: provide Supabase env vars to E2E CI job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,9 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://htohprkfygyzvgzijvnd.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## What does this PR do?

Follow-up to #17/PR #50 - the merged E2E workflow failed in CI: `lib/supabase.ts` throws at module-eval if `NEXT_PUBLIC_SUPABASE_URL`/`ANON_KEY` aren't set, crashing the dev server before Playwright's webServer readiness check, which then timed out after 120s.

Passes the same public Supabase anon key already committed as a fallback in `app/page.tsx` as env vars on the `test:e2e` step - not a new secret, no repo secrets needed.

## Type of change

- [x] Bug fix
- [ ] New scraper source
- [ ] Feature / enhancement
- [ ] Refactor / cleanup

## For new scrapers

N/A - not a scraper change.

## Checklist

- [x] TypeScript compiles with no errors (`npm run build`)
- [x] No `any` types introduced
- [x] No credentials or secrets in the code