### PR TITLE
fix: replace any types in Tournament (prize_distribution, schedule)

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -21,6 +21,18 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   },
 })
 
+export interface PrizeDistribution {
+  category: string
+  amount: string
+}
+
+export interface ScheduleItem {
+  date: string
+  time?: string
+  round?: number
+  description?: string
+}
+
 export type Tournament = {
   id: string
   name: string
@@ -54,8 +66,8 @@ export type Tournament = {
   external_link?: string
   rules: string[]
   amenities: string[]
-  prize_distribution: any
-  schedule: any[]
+  prize_distribution?: PrizeDistribution[] | null
+  schedule?: ScheduleItem[] | null
   status: string
   created_at?: string
   scraped_at?: string


### PR DESCRIPTION
## Summary

Resolves #57

Replaces the untyped \ny\ fields in the \Tournament\ type (\lib/supabase.ts\) with explicit, domain-appropriate interfaces:

- \prize_distribution?: PrizeDistribution[] | null\ — array of \{ category, amount }\
- \schedule?: ScheduleItem[] | null\ — array of \{ date, time?, round?, description? }\

Both are made optional/nullable because they map to JSONB columns in Supabase that may be null. No usage of these fields exists in the codebase, so this is purely a type-safety improvement.

## Verification
- \
px tsc --noEmit\ passes
- \
pm run lint\ passes