### PR TITLE
fix: remove stray console.log/console.error calls from lib/

### DIFF
--- a/lib/AuthContext.tsx
+++ b/lib/AuthContext.tsx
@@ -93,8 +93,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(null);
       setUserType(null);
       setLoading(false);
-    } catch (error) {
-      console.error("Auth check error:", error);
+    } catch {
       setUser(null);
       setUserType(null);
       setLoading(false);

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -18,8 +18,8 @@ export async function trackEvent(tournamentId: string, eventType: AnalyticsEvent
         event_category: 'tournament',
       });
     }
-  } catch (error) {
-    console.error("Failed to track event:", error);
+  } catch {
+    // Silently ignore tracking errors
   }
 }
 
@@ -45,8 +45,8 @@ export async function getAnalytics(tournamentId: string): Promise<Record<Analyti
         result[eventType]++;
       }
     }
-  } catch (error) {
-    console.error("Failed to get analytics:", error);
+  } catch {
+    // Silently ignore analytics fetch errors
   }
 
   return result;
@@ -81,8 +81,8 @@ export async function getAnalyticsForTournaments(tournamentIds: string[]): Promi
         result[tournamentId][eventType]++;
       }
     }
-  } catch (error) {
-    console.error("Failed to get analytics:", error);
+  } catch {
+    // Silently ignore batch analytics fetch errors
   }
 
   return result;

--- a/lib/geocoding.ts
+++ b/lib/geocoding.ts
@@ -88,8 +88,6 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
   
   if (!apiKey) {
-    console.error("❌ Google Maps API key not found in environment variables");
-    console.log("Add NEXT_PUBLIC_GOOGLE_MAPS_API_KEY to your .env.local file");
     return null;
   }
 
@@ -101,24 +99,14 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
     
     if (data.status === "OK" && data.results.length > 0) {
       const location = data.results[0].geometry.location;
-      console.log("✓ Geocoding successful:", {
-        address,
-        coordinates: location,
-        formatted_address: data.results[0].formatted_address
-      });
       return {
         lat: location.lat,
         lng: location.lng
       };
     } else {
-      console.error("❌ Geocoding failed:", {
-        status: data.status,
-        error_message: data.error_message || "No results found"
-      });
       return null;
     }
-  } catch (error) {
-    console.error("❌ Geocoding request error:", error);
+  } catch {
     return null;
   }
 }
@@ -233,8 +221,8 @@ async function geocodeWithNominatim(city: string, country?: string): Promise<{ l
         lng: parseFloat(data[0].lon)
       };
     }
-  } catch (error) {
-    console.error(`[Geocoding] Nominatim error for "${city}":`, error);
+  } catch {
+    // Silently ignore Nominatim errors
   }
   
   return null;
@@ -281,7 +269,6 @@ export async function geocodeTournaments(tournaments: any[]): Promise<any[]> {
   
   // Batch geocode unknown cities with Nominatim (rate limited)
   if (unknownCities.size > 0) {
-    console.log(`[Geocoding] ${unknownCities.size} unknown cities, using Nominatim...`);
     
     const cityCoords: Map<string, { lat: number; lng: number }> = new Map();
     

--- a/lib/tournaments.ts
+++ b/lib/tournaments.ts
@@ -92,7 +92,6 @@ export async function getUpcomingTournaments(
   const { data, error, count } = await query;
 
   if (error) {
-    console.error('Error fetching tournaments:', error);
     return {
       tournaments: [],
       total: 0,
@@ -161,7 +160,6 @@ export async function getAllUpcomingTournaments(
     .limit(limit);
 
   if (error) {
-    console.error('Error fetching all tournaments:', error);
     return [];
   }
 


### PR DESCRIPTION
Removes console.log and console.error calls from lib/ files per the project CONTRIBUTING.md style rules. Error handling is preserved (catch blocks remain), only the console output is removed. Affected files: analytics.ts, tournaments.ts, geocoding.ts, AuthContext.tsx. Closes #55