### PR TITLE
fix: add aria-live result count and aria-labels to tournament search boxes (#61)

### DIFF
--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -439,10 +439,12 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
 
             <div className="filters-grid">
               <div className="filter-group">
-                <label>Search</label>
+                <label htmlFor="tournament-search">Search</label>
                 <input
+                  id="tournament-search"
                   className="form-input"
                   placeholder="Tournament name..."
+                  aria-label="Search tournaments by name"
                   value={filters.search}
                   onChange={(e) => { markEngaged(); setFilters((p) => ({ ...p, search: e.target.value })); }}
                 />
@@ -552,6 +554,24 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
               >
                 ⭐ Star us on GitHub
               </a>
+            </div>
+
+            <div
+              aria-live="polite"
+              role="status"
+              style={{
+                position: 'absolute',
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: -1,
+                overflow: 'hidden',
+                clip: 'rect(0, 0, 0, 0)',
+                whiteSpace: 'nowrap',
+                border: 0,
+              }}
+            >
+              Showing {filtered.length} of {initialTournaments.length} tournaments
             </div>
 
             <div className="table-container">

--- a/app/tournaments/TournamentsClient.tsx
+++ b/app/tournaments/TournamentsClient.tsx
@@ -89,6 +89,7 @@ export default function TournamentsClient({ initialTournaments }: Props) {
               <input
                 type="text"
                 placeholder="Search tournaments, locations, organizers..."
+                aria-label="Search tournaments by name, location, or organizer"
                 value={searchQuery}
                 onChange={(e) => { markEngaged(); setSearchQuery(e.target.value); }}
                 className="form-input"
@@ -98,17 +99,22 @@ export default function TournamentsClient({ initialTournaments }: Props) {
                   fontSize: "1rem"
                 }}
               />
-              <span style={{
-                position: "absolute",
-                left: "1rem",
-                top: "50%",
-                transform: "translateY(-50%)",
-                fontSize: "1.25rem",
-                color: "var(--text-secondary)"
-              }}>                
+              <span
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  left: "1rem",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  fontSize: "1.25rem",
+                  color: "var(--text-secondary)"
+                }}
+              >
               </span>
               {searchQuery && (
                 <button
+                  type="button"
+                  aria-label="Clear search"
                   onClick={() => setSearchQuery('')}
                   style={{
                     position: "absolute",
@@ -127,12 +133,16 @@ export default function TournamentsClient({ initialTournaments }: Props) {
               )}
             </div>
             {debouncedSearch && (
-              <p style={{ 
-                textAlign: "center", 
-                marginTop: "1rem", 
-                color: "var(--text-secondary)",
-                fontSize: "0.875rem"
-              }}>
+              <p
+                aria-live="polite"
+                role="status"
+                style={{ 
+                  textAlign: "center", 
+                  marginTop: "1rem", 
+                  color: "var(--text-secondary)",
+                  fontSize: "0.875rem"
+                }}
+              >
                 Found {filteredTournaments.length} tournament{filteredTournaments.length !== 1 ? 's' : ''}
               </p>
             )}


### PR DESCRIPTION
## Summary

Resolves #61

Improves accessibility of the tournament search boxes:

**Tournaments list page (`app/tournaments/TournamentsClient.tsx`)**
- Added `aria-label` to the search input.
- Marked the decorative search-icon span `aria-hidden`.
- Added `aria-label="Clear search"` to the clear (×) button.
- Added `aria-live="polite"` + `role="status"` to the `Found N tournaments` result count so screen readers announce updates as the user types.

**Homepage map/filter panel (`app/HomePageClient.tsx`)**
- Associated the `Search` label with the input via `htmlFor`/`id`.
- Added `aria-label="Search tournaments by name"` to the input.
- Added a visually-hidden `aria-live="polite"` + `role="status"` region announcing `Showing N of M tournaments`.

## Verification
- `npx tsc --noEmit` passes
- `npm run lint` passes
