### PR TITLE
fix: tournament search a11y + validated limit & real pagination (#61, #56)

### DIFF
--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -439,10 +439,12 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
 
             <div className="filters-grid">
               <div className="filter-group">
-                <label>Search</label>
+                <label htmlFor="tournament-search">Search</label>
                 <input
+                  id="tournament-search"
                   className="form-input"
                   placeholder="Tournament name..."
+                  aria-label="Search tournaments by name"
                   value={filters.search}
                   onChange={(e) => { markEngaged(); setFilters((p) => ({ ...p, search: e.target.value })); }}
                 />
@@ -552,6 +554,24 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
               >
                 ⭐ Star us on GitHub
               </a>
+            </div>
+
+            <div
+              aria-live="polite"
+              role="status"
+              style={{
+                position: 'absolute',
+                width: 1,
+                height: 1,
+                padding: 0,
+                margin: -1,
+                overflow: 'hidden',
+                clip: 'rect(0, 0, 0, 0)',
+                whiteSpace: 'nowrap',
+                border: 0,
+              }}
+            >
+              Showing {filtered.length} of {initialTournaments.length} tournaments
             </div>
 
             <div className="table-container">

--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,54 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
-
-const OPTIMIZED_SELECT = `
-  id,
-  name,
-  date,
-  end_date,
-  city,
-  state,
-  country,
-  country_code,
-  category,
-  fide_rated,
-  lat,
-  lng,
-  source_url,
-  external_link,
-  location,
-  created_at
-`;
+import { queryTournaments } from '@/lib/tournaments';
 
 export async function GET(request: NextRequest) {
-  
   const { searchParams } = new URL(request.url);
   const country = searchParams.get('country');
-  const limit = parseInt(searchParams.get('limit') || '100');
+  const q = searchParams.get('q');
 
-  const today = new Date().toISOString().split('T')[0];
-  let query = supabase
-    .from('tournaments')
-    .select(OPTIMIZED_SELECT)
-    .eq('status', 'published')
-    .gte('date', today)
-    .order('date', { ascending: true });
-  
-  if (country) {
-    query = query.eq('country_code', country.toUpperCase());
-  }
-  
-  query = query.limit(limit);
-  
-  const { data, error } = await query;
-  
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  
-  return NextResponse.json({ tournaments: data }, {
+  const limitParam = parseInt(searchParams.get('limit') || '', 10);
+  const pageParam = parseInt(searchParams.get('page') || '', 10);
+
+  const result = await queryTournaments({
+    limit: Number.isNaN(limitParam) ? undefined : limitParam,
+    page: Number.isNaN(pageParam) ? undefined : pageParam,
+    country,
+    q,
+  });
+
+  return NextResponse.json(result, {
     headers: {
       'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600',
-    }
+    },
   });
 }

--- a/app/tournaments/TournamentsClient.tsx
+++ b/app/tournaments/TournamentsClient.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useMemo, useEffect } from "react";
 import BaseLayout from "@/components/BaseLayout";
-import TournamentCardSkeleton from "@/components/TournamentCardSkeleton";
 import { getCountdown, isNewTournament } from "@/lib/countdown";
 import { trackEvent } from "@/lib/track";
 
@@ -27,6 +25,10 @@ interface Tournament {
 
 interface Props {
   initialTournaments: Tournament[];
+  page: number;
+  totalPages: number;
+  total: number;
+  q: string;
 }
 
 function formatDate(dateStr: string): string {
@@ -39,36 +41,7 @@ function formatDate(dateStr: string): string {
   }).format(d);
 }
 
-export default function TournamentsClient({ initialTournaments }: Props) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchQuery);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
-
-  const safeIncludes = (str: string | null | undefined, search: string): boolean => {
-    return str?.toLowerCase().includes(search.toLowerCase()) ?? false;
-  };
-
-  const filteredTournaments = useMemo(() => {
-    return initialTournaments.filter((t: Tournament) => {
-      if (!debouncedSearch) return true;
-      const query = debouncedSearch.toLowerCase();
-      return (
-        safeIncludes(t.name, query) ||
-        safeIncludes(t.location, query) ||
-        safeIncludes(t.city, query) ||
-        safeIncludes(t.state, query) ||
-        safeIncludes(t.country, query) ||
-        safeIncludes(t.organizer_name, query)
-      );
-    });
-  }, [initialTournaments, debouncedSearch]);
-
+export default function TournamentsClient({ initialTournaments, page, totalPages, total, q }: Props) {
   // Signal StarPrompt that the user got value (searched / opened a tournament).
   const markEngaged = () => {
     if (typeof window !== "undefined") {
@@ -76,40 +49,59 @@ export default function TournamentsClient({ initialTournaments }: Props) {
     }
   };
 
+  const buildHref = (targetPage: number) => {
+    const params = new URLSearchParams();
+    if (q.trim()) params.set("q", q.trim());
+    if (targetPage > 1) params.set("page", String(targetPage));
+    const qs = params.toString();
+    return qs ? `/tournaments?${qs}` : "/tournaments";
+  };
+
   return (
-    <BaseLayout 
-      showHero 
+    <BaseLayout
+      showHero
       heroTitle={<>Upcoming <span className="highlight">Tournaments</span></>}
       heroDescription="Browse over-the-board chess tournaments from around the world. Data sourced from Chess-Results.com."
     >
       <section className="tournament-section">
         <div className="section-container">
           <div style={{ marginBottom: "2rem" }}>
-            <div style={{ position: "relative", maxWidth: "600px", margin: "0 auto" }}>
+            <form
+              method="get"
+              action="/tournaments"
+              onSubmit={markEngaged}
+              style={{ position: "relative", maxWidth: "600px", margin: "0 auto" }}
+            >
               <input
                 type="text"
+                name="q"
+                defaultValue={q}
                 placeholder="Search tournaments, locations, organizers..."
-                value={searchQuery}
-                onChange={(e) => { markEngaged(); setSearchQuery(e.target.value); }}
+                aria-label="Search tournaments by name, location, or organizer"
                 className="form-input"
                 style={{
                   width: "100%",
                   paddingLeft: "3rem",
-                  fontSize: "1rem"
+                  fontSize: "1rem",
                 }}
               />
-              <span style={{
-                position: "absolute",
-                left: "1rem",
-                top: "50%",
-                transform: "translateY(-50%)",
-                fontSize: "1.25rem",
-                color: "var(--text-secondary)"
-              }}>                
+              <span
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  left: "1rem",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  fontSize: "1.25rem",
+                  color: "var(--text-secondary)",
+                }}
+              >
               </span>
-              {searchQuery && (
-                <button
-                  onClick={() => setSearchQuery('')}
+              {q && (
+                <Link
+                  href="/tournaments"
+                  aria-label="Clear search"
+                  onClick={markEngaged}
                   style={{
                     position: "absolute",
                     right: "1rem",
@@ -119,32 +111,35 @@ export default function TournamentsClient({ initialTournaments }: Props) {
                     border: "none",
                     fontSize: "1.25rem",
                     cursor: "pointer",
-                    color: "var(--text-secondary)"
+                    color: "var(--text-secondary)",
                   }}
                 >
                   ×
-                </button>
+                </Link>
               )}
-            </div>
-            {debouncedSearch && (
-              <p style={{ 
-                textAlign: "center", 
-                marginTop: "1rem", 
+            </form>
+
+            <p
+              aria-live="polite"
+              role="status"
+              style={{
+                textAlign: "center",
+                marginTop: "1rem",
                 color: "var(--text-secondary)",
-                fontSize: "0.875rem"
-              }}>
-                Found {filteredTournaments.length} tournament{filteredTournaments.length !== 1 ? 's' : ''}
-              </p>
-            )}
+                fontSize: "0.875rem",
+              }}
+            >
+              {total} tournament{total !== 1 ? "s" : ""} found{q ? ` for "${q}"` : ""}
+            </p>
           </div>
 
-          {filteredTournaments.length === 0 ? (
+          {initialTournaments.length === 0 ? (
             <div className="loading-message">
-              {debouncedSearch ? `No tournaments found for "${debouncedSearch}"` : "No tournaments found."}
+              {q ? `No tournaments found for "${q}"` : "No tournaments found."}
             </div>
           ) : (
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 350px), 1fr))", gap: "1.5rem" }}>
-              {filteredTournaments.map((tournament: Tournament) => (
+              {initialTournaments.map((tournament: Tournament) => (
                 <div key={tournament.id} className="card" style={{ display: "flex", flexDirection: "column" }}>
                   <div style={{ marginBottom: "1rem" }}>
                     <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
@@ -208,7 +203,34 @@ export default function TournamentsClient({ initialTournaments }: Props) {
             </div>
           )}
 
-          {filteredTournaments.length > 0 && (
+          {totalPages > 1 && (
+            <nav
+              aria-label="Tournament pagination"
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                gap: "1rem",
+                marginTop: "2rem",
+              }}
+            >
+              {page > 1 ? (
+                <Link href={buildHref(page - 1)} className="btn">← Previous</Link>
+              ) : (
+                <span className="btn" style={{ opacity: 0.5, pointerEvents: "none" }}>← Previous</span>
+              )}
+              <span style={{ fontSize: "0.875rem", color: "var(--text-secondary)" }}>
+                Page {page} of {totalPages}
+              </span>
+              {page < totalPages ? (
+                <Link href={buildHref(page + 1)} className="btn">Next →</Link>
+              ) : (
+                <span className="btn" style={{ opacity: 0.5, pointerEvents: "none" }}>Next →</span>
+              )}
+            </nav>
+          )}
+
+          {initialTournaments.length > 0 && (
             <p style={{ textAlign: "center", marginTop: "2rem", fontSize: "0.875rem", color: "var(--text-secondary)" }}>
               Find this useful?{' '}
               <a

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,62 +1,37 @@
-import { createClient } from '@supabase/supabase-js';
 import { unstable_cache } from 'next/cache';
 import TournamentsClient from './TournamentsClient';
 import type { Metadata } from 'next';
+import { queryTournaments } from '@/lib/tournaments';
 
 export const metadata: Metadata = {
   title: 'Browse Chess Tournaments',
   description: 'Browse and filter 500+ upcoming chess tournaments worldwide. Filter by country, format, date, and FIDE rating status.',
 };
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://htohprkfygyzvgzijvnd.supabase.co";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA";
+export default async function TournamentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; q?: string }>;
+}) {
+  const sp = await searchParams;
+  const page = parseInt(sp.page || '1', 10);
+  const q = sp.q || '';
 
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const getTournaments = unstable_cache(
+    async () => queryTournaments({ page, q }),
+    ['tournaments-list', String(page), q || ''],
+    { revalidate: 86400, tags: ['tournaments'] }
+  );
 
-const OPTIMIZED_SELECT = `
-  id,
-  name,
-  date,
-  end_date,
-  city,
-  state,
-  country,
-  country_code,
-  category,
-  fide_rated,
-  lat,
-  lng,
-  source_url,
-  external_link,
-  location,
-  organizer_name,
-  created_at
-`;
+  const result = await getTournaments();
 
-const getCachedTournaments = unstable_cache(
-  async () => {
-    const today = new Date().toISOString().split('T')[0];
-    
-    const { data, error } = await supabase
-      .from('tournaments')
-      .select(OPTIMIZED_SELECT)
-      .gte('date', today)
-      .eq('status', 'published')
-      .order('date', { ascending: true })
-      .order('created_at', { ascending: false });
-    
-    if (error) {
-      console.error('Error:', error);
-      return [];
-    }
-    
-    return data || [];
-  },
-  ['tournaments-list'],
-  { revalidate: 86400, tags: ['tournaments'] }
-);
-
-export default async function TournamentsPage() {
-  const tournaments = await getCachedTournaments();
-  return <TournamentsClient initialTournaments={tournaments} />;
+  return (
+    <TournamentsClient
+      initialTournaments={result.tournaments}
+      page={result.page}
+      totalPages={result.totalPages}
+      total={result.total}
+      q={q}
+    />
+  );
 }

--- a/lib/tournaments.ts
+++ b/lib/tournaments.ts
@@ -167,3 +167,88 @@ export async function getAllUpcomingTournaments(
 
   return data || [];
 }
+
+const TOURNAMENT_MAX_LIMIT = 200;
+const TOURNAMENT_DEFAULT_LIMIT = 100;
+
+export interface TournamentQuery {
+  page?: number;
+  limit?: number;
+  country?: string | null;
+  q?: string | null;
+}
+
+export interface TournamentPage {
+  tournaments: TournamentListItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+// Shared, validated query used by both the /api/tournaments endpoint and the
+// tournaments page. Clamps `limit` to a safe range, derives `page` from a
+// 1-based index, supports optional country filtering and free-text search, and
+// returns the total count so callers can render real pagination.
+export async function queryTournaments({
+  page = 1,
+  limit = TOURNAMENT_DEFAULT_LIMIT,
+  country,
+  q,
+}: TournamentQuery = {}): Promise<TournamentPage> {
+  const safeLimit =
+    Number.isInteger(limit) && limit > 0
+      ? Math.min(limit, TOURNAMENT_MAX_LIMIT)
+      : TOURNAMENT_DEFAULT_LIMIT;
+  const safePage = Number.isInteger(page) && page > 0 ? page : 1;
+  const start = (safePage - 1) * safeLimit;
+  const end = start + safeLimit - 1;
+  const today = new Date().toISOString().split('T')[0];
+
+  let query = supabase
+    .from('tournaments')
+    .select(TOURNAMENT_SELECT_FIELDS, { count: 'exact' })
+    .eq('status', 'published')
+    .gte('date', today)
+    .order('date', { ascending: true })
+    .order('created_at', { ascending: false })
+    .range(start, end);
+
+  if (country) {
+    query = query.eq('country_code', country.toUpperCase());
+  }
+
+  if (q && q.trim()) {
+    const term = q.trim().replace(/[%_\\]/g, '\\$&');
+    query = query.or(
+      `name.ilike.%${term}%,location.ilike.%${term}%,city.ilike.%${term}%,state.ilike.%${term}%,country.ilike.%${term}%,organizer_name.ilike.%${term}%`
+    );
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error('Error fetching tournaments:', error);
+    return {
+      tournaments: [],
+      total: 0,
+      page: safePage,
+      limit: safeLimit,
+      totalPages: 0,
+      hasMore: false,
+    };
+  }
+
+  const total = count || 0;
+  const totalPages = Math.max(1, Math.ceil(total / safeLimit));
+
+  return {
+    tournaments: data || [],
+    total,
+    page: safePage,
+    limit: safeLimit,
+    totalPages,
+    hasMore: safePage < totalPages,
+  };
+}

--- a/lib/tournaments.ts
+++ b/lib/tournaments.ts
@@ -220,7 +220,10 @@ export async function queryTournaments({
   }
 
   if (q && q.trim()) {
-    const term = q.trim().replace(/[%_\\]/g, '\\$&');
+    // Strip PostgREST .or() delimiter/grouping characters ( , ( ) " ) before
+    // escaping SQL LIKE wildcards, otherwise a crafted query could inject
+    // extra filter clauses and be used as a boolean oracle.
+    const term = q.trim().replace(/[,()"]/g, '').replace(/[%_\\]/g, '\\$&');
     query = query.or(
       `name.ilike.%${term}%,location.ilike.%${term}%,city.ilike.%${term}%,state.ilike.%${term}%,country.ilike.%${term}%,organizer_name.ilike.%${term}%`
     );


### PR DESCRIPTION
## Summary

Combines #61 (search-box accessibility) and #56 (unvalidated `limit` + unbounded fetch) into a single PR, since both touch `app/tournaments/TournamentsClient.tsx` and would otherwise conflict.

### Accessibility (#61)
**`app/tournaments/TournamentsClient.tsx`**
- `aria-label` on the search input.
- `aria-hidden` on the decorative search-icon span.
- `aria-label="Clear search"` on the clear (×) button.
- `aria-live="polite"` + `role="status"` on the result count.

**`app/HomePageClient.tsx`**
- Associated the `Search` label with the input via `htmlFor`/`id`.
- `aria-label="Search tournaments by name"` on the input.
- Visually-hidden `aria-live="polite"` + `role="status"` region announcing `Showing N of M tournaments`.

### Validated limit + real pagination (#56)
**`lib/tournaments.ts`** — added shared `queryTournaments({ page, limit, country, q })` that clamps `limit` to `[1, 200]` (default `100`), derives a 1-based `page`, returns `{ tournaments, total, page, limit, totalPages, hasMore }` via Supabase `count: 'exact'` + `.range()`, and supports optional free-text `q` search (with `%`, `_`, `\` escaped for `ilike`).

**`app/api/tournaments/route.ts`** — uses `queryTournaments`; `limit`/`page` validated (NaN → defaults); returns the pagination envelope. Bad input no longer silently falls through.

**`app/tournaments/page.tsx`** — no longer fetches all rows. Reads `page`/`q` from `searchParams`, calls `queryTournaments` (cached per page/query), passes `page`/`totalPages`/`total` to the client. Also removed the dead hardcoded Supabase URL/anon-key fallback.

**`app/tournaments/TournamentsClient.tsx`** — search is now server-driven via a `GET` form (`?q=`), with real pagination controls (Previous / Next + "Page X of Y").

## Verification
- `npx tsc --noEmit` passes
- `npm run lint` passes

Note: the tournaments page consumes the same validated/paginated query logic as the endpoint (via the shared helper) rather than issuing an internal HTTP call.
