### PR TITLE
fix: remove stray console.log from lib/geocoding.ts (#55)

### DIFF
--- a/lib/geocoding.ts
+++ b/lib/geocoding.ts
@@ -89,7 +89,6 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
   
   if (!apiKey) {
     console.error("❌ Google Maps API key not found in environment variables");
-    console.log("Add NEXT_PUBLIC_GOOGLE_MAPS_API_KEY to your .env.local file");
     return null;
   }
 
@@ -101,11 +100,6 @@ export async function geocodeAddress(address: string): Promise<{ lat: number; ln
     
     if (data.status === "OK" && data.results.length > 0) {
       const location = data.results[0].geometry.location;
-      console.log("✓ Geocoding successful:", {
-        address,
-        coordinates: location,
-        formatted_address: data.results[0].formatted_address
-      });
       return {
         lat: location.lat,
         lng: location.lng
@@ -281,8 +275,6 @@ export async function geocodeTournaments(tournaments: any[]): Promise<any[]> {
   
   // Batch geocode unknown cities with Nominatim (rate limited)
   if (unknownCities.size > 0) {
-    console.log(`[Geocoding] ${unknownCities.size} unknown cities, using Nominatim...`);
-    
     const cityCoords: Map<string, { lat: number; lng: number }> = new Map();
     
     for (const cityKey of unknownCities) {


### PR DESCRIPTION
Removes 3 \console.log\ calls from \lib/geocoding.ts\ that violate the CONTRIBUTING.md rule:

> *No \console.log\ in API routes or \lib/\.*

\console.error\ calls are retained — they are compliant per commit 43a1752 which established that only \console.log\ is banned in \lib/\.

Fixes #55 (the actual \console.log\ violations; \console.error\ calls already comply with the project's rule).