### PR TITLE
Security hardening: credential removal, wishlist IDOR, RLS, param validation

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,32 @@
+name: Secret scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Credentials belong in env vars only. Example files may carry
+      # placeholders, so they are the single exception.
+      - name: Fail on committed Supabase project URLs
+        run: |
+          if git grep -nE 'https://[a-z0-9]{20}\.supabase\.co' \
+               -- . ':(exclude)*.example' ':(exclude)package-lock.json'; then
+            echo "::error::Hardcoded Supabase project URL found. Use NEXT_PUBLIC_SUPABASE_URL."
+            exit 1
+          fi
+
+      - name: Fail on committed JWTs
+        run: |
+          if git grep -nE 'eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}' \
+               -- . ':(exclude)*.example' ':(exclude)package-lock.json'; then
+            echo "::error::Committed JWT found. Supabase keys must come from env vars."
+            exit 1
+          fi

--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -560,7 +560,13 @@ export default function HomePageClient({ initialTournaments, stats }: Props) {
                 border: 0,
               }}
             >
-              Showing {paginated.length} of {filtered.length} tournaments, page {tablePage} of {totalPages}
+              {filtered.length === 0
+                ? filters.search
+                  ? `No tournaments match "${filters.search}"`
+                  : "No tournaments match your filters"
+                : `${filtered.length} tournament${filtered.length === 1 ? "" : "s"} found${
+                    filters.search ? ` for "${filters.search}"` : ""
+                  }, showing ${paginated.length} on page ${tablePage} of ${totalPages}`}
             </div>
 
             <div className="table-container">

--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,19 +1,46 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { queryTournaments } from '@/lib/tournaments';
 
+// queryTournaments clamps limit and page defensively, but silently coercing a
+// bad value hides caller bugs and makes the API look like it accepted input it
+// actually ignored. Reject anything non-numeric up front and let the clamp
+// handle the merely-too-large case.
+function parseBounded(
+  raw: string | null,
+  name: string
+): { value?: number; error?: string } {
+  if (raw === null || raw === '') return {};
+
+  if (!/^\d+$/.test(raw)) {
+    return { error: `${name} must be a positive integer` };
+  }
+
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    return { error: `${name} must be a positive integer` };
+  }
+
+  return { value };
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const country = searchParams.get('country');
-  const q = searchParams.get('q');
 
-  const limitParam = parseInt(searchParams.get('limit') || '', 10);
-  const pageParam = parseInt(searchParams.get('page') || '', 10);
+  const limit = parseBounded(searchParams.get('limit'), 'limit');
+  if (limit.error) {
+    return NextResponse.json({ error: limit.error }, { status: 400 });
+  }
+
+  const page = parseBounded(searchParams.get('page'), 'page');
+  if (page.error) {
+    return NextResponse.json({ error: page.error }, { status: 400 });
+  }
 
   const result = await queryTournaments({
-    limit: Number.isNaN(limitParam) ? undefined : limitParam,
-    page: Number.isNaN(pageParam) ? undefined : pageParam,
-    country,
-    q,
+    limit: limit.value,
+    page: page.value,
+    country: searchParams.get('country'),
+    q: searchParams.get('q'),
   });
 
   return NextResponse.json(result, {

--- a/app/api/wishlist/route.ts
+++ b/app/api/wishlist/route.ts
@@ -1,66 +1,83 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { getAuthenticatedPlayer } from '@/lib/supabase-server';
+
+// Every handler here derives the player id from the caller's verified access
+// token. A player_id supplied in the query string or body is ignored, so one
+// player can never read or mutate another player's wishlist.
+const UNAUTHORIZED = { error: 'Authentication required' };
 
 export async function GET(request: NextRequest) {
-  
-  const { searchParams } = new URL(request.url);
-  const playerId = searchParams.get('player_id');
-  
-  if (!playerId) {
-    return NextResponse.json({ error: 'player_id required' }, { status: 400 });
+  const player = await getAuthenticatedPlayer(request);
+  if (!player) {
+    return NextResponse.json(UNAUTHORIZED, { status: 401 });
   }
-  
-  const { data, error } = await supabase
+
+  const { data, error } = await player.supabase
     .from('player_favorite_tournaments')
     .select('tournament_id, created_at')
-    .eq('player_id', playerId);
-  
+    .eq('player_id', player.playerId);
+
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  
-  return NextResponse.json({ wishlist: data });
+
+  return NextResponse.json(
+    { wishlist: data },
+    { headers: { 'Cache-Control': 'private, no-store' } }
+  );
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const { player_id, tournament_id } = body;
-  
-  if (!player_id || !tournament_id) {
-    return NextResponse.json({ error: 'player_id and tournament_id required' }, { status: 400 });
+  const player = await getAuthenticatedPlayer(request);
+  if (!player) {
+    return NextResponse.json(UNAUTHORIZED, { status: 401 });
   }
-  
-  const { data, error } = await supabase
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const tournamentId = (body as { tournament_id?: unknown })?.tournament_id;
+  if (typeof tournamentId !== 'string' || !tournamentId.trim()) {
+    return NextResponse.json({ error: 'tournament_id required' }, { status: 400 });
+  }
+
+  const { data, error } = await player.supabase
     .from('player_favorite_tournaments')
-    .insert({ player_id, tournament_id })
+    .insert({ player_id: player.playerId, tournament_id: tournamentId })
     .select()
     .single();
-  
+
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  
-  return NextResponse.json({ success: true, data });
+
+  return NextResponse.json({ success: true, data }, { status: 201 });
 }
 
 export async function DELETE(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const playerId = searchParams.get('player_id');
-  const tournamentId = searchParams.get('tournament_id');
-  
-  if (!playerId || !tournamentId) {
-    return NextResponse.json({ error: 'player_id and tournament_id required' }, { status: 400 });
+  const player = await getAuthenticatedPlayer(request);
+  if (!player) {
+    return NextResponse.json(UNAUTHORIZED, { status: 401 });
   }
-  
-  const { error } = await supabase
+
+  const tournamentId = new URL(request.url).searchParams.get('tournament_id');
+  if (!tournamentId) {
+    return NextResponse.json({ error: 'tournament_id required' }, { status: 400 });
+  }
+
+  const { error } = await player.supabase
     .from('player_favorite_tournaments')
     .delete()
-    .eq('player_id', playerId)
+    .eq('player_id', player.playerId)
     .eq('tournament_id', tournamentId);
-  
+
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  
+
   return NextResponse.json({ success: true });
 }

--- a/app/country/[code]/page.tsx
+++ b/app/country/[code]/page.tsx
@@ -1,14 +1,9 @@
 import { Metadata } from 'next';
-import { createClient } from '@supabase/supabase-js';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import BaseLayout from '../../../components/BaseLayout';
 import { generateCountryMetadata, generateBreadcrumbJsonLd, getCountryName, COUNTRY_NAMES } from '../../lib/metadata';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://htohprkfygyzvgzijvnd.supabase.co";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA";
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from '@/lib/supabase';
 
 type Props = {
   params: Promise<{ code: string }>;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,26 +2,13 @@ import { unstable_cache } from 'next/cache';
 import HomePageClient from './HomePageClient';
 import { generateOrganizationJsonLd, generateWebsiteJsonLd } from '@/app/lib/metadata';
 import { supabase } from '@/lib/supabase';
+import { getMapTournaments } from '@/lib/tournaments';
+
+const MAP_FIELDS =
+  'id, name, date, end_date, city, state, country, country_code, lat, lng, category, fide_rated, source_url, external_link, location';
 
 const getCachedTournaments = unstable_cache(
-  async () => {
-    const today = new Date().toISOString().split('T')[0];
-
-    const { data, error } = await supabase
-      .from('tournaments')
-      .select('id, name, date, end_date, city, state, country, country_code, lat, lng, category, fide_rated, source_url, external_link, location')
-      .gte('date', today)
-      .eq('status', 'published')
-      .order('date', { ascending: true })
-      .limit(1000);
-
-    if (error) {
-      console.error('Supabase error:', error);
-      return [];
-    }
-
-    return data || [];
-  },
+  async () => getMapTournaments(MAP_FIELDS),
   ['home-tournaments'],
   { revalidate: 86400, tags: ['tournaments'] }
 );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,7 @@
-import { createClient } from '@supabase/supabase-js';
 import { unstable_cache } from 'next/cache';
 import HomePageClient from './HomePageClient';
 import { generateOrganizationJsonLd, generateWebsiteJsonLd } from '@/app/lib/metadata';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://htohprkfygyzvgzijvnd.supabase.co";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA";
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from '@/lib/supabase';
 
 const getCachedTournaments = unstable_cache(
   async () => {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,5 @@
 import { MetadataRoute } from 'next';
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://htohprkfygyzvgzijvnd.supabase.co";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA";
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from '@/lib/supabase';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.tourneyradar.com';

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -1,12 +1,7 @@
 import { Metadata } from 'next';
-import { createClient } from '@supabase/supabase-js';
 import TournamentDetailClient from './TournamentDetailClient';
 import { generateTournamentJsonLd, generateBreadcrumbJsonLd } from '../../lib/metadata';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://htohprkfygyzvgzijvnd.supabase.co";
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh0b2hwcmtmeWd5enZnemlqdm5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY2NDY3MDMsImV4cCI6MjA4MjIyMjcwM30.4TYIhteDvauPVtWbWp_Dql3VgJcYsdhgYq65Z6kGDfA";
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from '@/lib/supabase';
 
 type Props = {
   params: Promise<{ id: string }>;

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,0 +1,72 @@
+import { createClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set'
+  );
+}
+
+// Route handlers must never trust a player id supplied by the caller. This
+// builds a request-scoped client bound to the caller's own access token, so
+// every query it makes runs as that user and RLS applies to it.
+function clientForToken(accessToken: string) {
+  return createClient(supabaseUrl!, supabaseAnonKey!, {
+    db: { schema: 'public' },
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+function bearerToken(request: NextRequest): string | null {
+  const header = request.headers.get('authorization');
+  if (!header) return null;
+
+  const [scheme, token] = header.split(' ');
+  if (!scheme || scheme.toLowerCase() !== 'bearer' || !token) return null;
+
+  return token.trim() || null;
+}
+
+export interface AuthenticatedPlayer {
+  playerId: string;
+  authUserId: string;
+  supabase: ReturnType<typeof clientForToken>;
+}
+
+/**
+ * Resolves the calling player from the request's bearer token.
+ *
+ * Returns null when the token is absent, invalid, expired, or belongs to an
+ * authenticated user with no matching row in `players`. Callers must treat
+ * null as 401 and must derive the player id from here rather than from any
+ * query string or request body value.
+ */
+export async function getAuthenticatedPlayer(
+  request: NextRequest
+): Promise<AuthenticatedPlayer | null> {
+  const token = bearerToken(request);
+  if (!token) return null;
+
+  const scoped = clientForToken(token);
+
+  const {
+    data: { user },
+    error: userError,
+  } = await scoped.auth.getUser(token);
+
+  if (userError || !user) return null;
+
+  const { data: player, error: playerError } = await scoped
+    .from('players')
+    .select('id')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (playerError || !player) return null;
+
+  return { playerId: player.id, authUserId: user.id, supabase: scoped };
+}

--- a/lib/tournaments.ts
+++ b/lib/tournaments.ts
@@ -168,6 +168,48 @@ export async function getAllUpcomingTournaments(
   return data || [];
 }
 
+// Supabase caps a single response, and the dataset has outgrown any one page,
+// so a bare .limit(n) silently truncates. Walks fixed-size pages instead and
+// stops on a short page, so every marker reaches the map without ever holding
+// an unbounded single query open. Callers are expected to cache the result.
+const MAP_PAGE_SIZE = 1000;
+const MAP_MAX_PAGES = 20;
+
+export async function getMapTournaments(
+  fields: string = TOURNAMENT_SELECT_FIELDS
+): Promise<TournamentListItem[]> {
+  const today = new Date().toISOString().split('T')[0];
+  const all: TournamentListItem[] = [];
+
+  for (let page = 0; page < MAP_MAX_PAGES; page++) {
+    const start = page * MAP_PAGE_SIZE;
+
+    const { data, error } = await supabase
+      .from('tournaments')
+      .select(fields)
+      .gte('date', today)
+      .eq('status', 'published')
+      .order('date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(start, start + MAP_PAGE_SIZE - 1);
+
+    if (error) {
+      console.error('Error fetching map tournaments:', error);
+      break;
+    }
+
+    const rows = (data || []) as unknown as TournamentListItem[];
+    all.push(...rows);
+
+    if (rows.length < MAP_PAGE_SIZE) return all;
+  }
+
+  console.warn(
+    `getMapTournaments hit the ${MAP_MAX_PAGES}-page ceiling; results may be truncated`
+  );
+  return all;
+}
+
 const TOURNAMENT_MAX_LIMIT = 200;
 const TOURNAMENT_DEFAULT_LIMIT = 100;
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,43 @@
+# Database migrations
+
+`docs/ARCHITECTURE.md` has always referred to this directory, but it did not
+exist in the repository until now, so no schema or policy was under version
+control. Migrations added from this point forward live here.
+
+The historical schema (tournaments, players, admins, scraper_logs and friends)
+was created through the Supabase dashboard and is not reproduced here. Treat
+these files as the record of changes going forward, not as a full rebuild.
+
+## Applying a migration
+
+Via the Supabase CLI, against a branch or staging project first:
+
+```bash
+supabase link --project-ref <ref>
+supabase db push
+```
+
+Or paste the SQL into the dashboard SQL editor.
+
+## 20260729000000_wishlist_rls.sql
+
+Enables Row Level Security on `players` and `player_favorite_tournaments`,
+and adds a `current_player_id()` helper that maps the current JWT to a
+`players.id`.
+
+This is the database-level half of the wishlist authorization fix. The
+application half is `getAuthenticatedPlayer()` in `lib/supabase-server.ts`,
+used by `app/api/wishlist/route.ts`. Both are needed: the route protects the
+API surface, and RLS protects the direct anon-key queries that
+`app/player/wishlist/page.tsx` still makes from the browser.
+
+**Verify after applying**, with a signed-in player:
+
+1. `/player/wishlist` still lists that player's tournaments.
+2. Adding and removing a tournament still works.
+3. A second player's `player_id` returns zero rows rather than their data.
+4. A signed-out browser gets nothing from either table.
+
+If step 1 or 2 fails, the likely cause is that `players.auth_user_id` is null
+for that account, which breaks the ownership chain. Backfill it before
+retrying rather than loosening the policies.

--- a/supabase/migrations/20260729000000_wishlist_rls.sql
+++ b/supabase/migrations/20260729000000_wishlist_rls.sql
@@ -1,0 +1,82 @@
+-- Row Level Security for player-owned tables.
+--
+-- Background: player_favorite_tournaments was reachable with the anon key and
+-- filtered only by a client-supplied player_id, both through /api/wishlist and
+-- directly from app/player/wishlist/page.tsx. The route now derives the player
+-- from a verified bearer token, but the browser still queries this table with
+-- the anon key, so the database itself has to enforce ownership.
+--
+-- Ownership chain: auth.users.id -> players.auth_user_id -> players.id
+--                  -> player_favorite_tournaments.player_id
+--
+-- APPLY WITH CARE. Enabling RLS denies everything not explicitly permitted.
+-- Run against a branch or staging project first and confirm the wishlist page
+-- still loads for a signed-in player before applying to production.
+
+-- Resolves the players.id belonging to the current JWT. SECURITY DEFINER so the
+-- lookup itself is not subject to the players policies below, which would
+-- otherwise recurse. STABLE so Postgres can cache it per statement.
+create or replace function public.current_player_id()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select id from public.players where auth_user_id = auth.uid()
+$$;
+
+revoke all on function public.current_player_id() from public;
+grant execute on function public.current_player_id() to authenticated;
+
+-- players ---------------------------------------------------------------
+
+alter table public.players enable row level security;
+
+drop policy if exists "players read own row" on public.players;
+create policy "players read own row"
+  on public.players
+  for select
+  using (auth_user_id = auth.uid());
+
+drop policy if exists "players update own row" on public.players;
+create policy "players update own row"
+  on public.players
+  for update
+  using (auth_user_id = auth.uid())
+  with check (auth_user_id = auth.uid());
+
+-- Registration inserts the row immediately after sign-up, so the new user must
+-- be allowed to create exactly one row pointing at themselves.
+drop policy if exists "players insert own row" on public.players;
+create policy "players insert own row"
+  on public.players
+  for insert
+  with check (auth_user_id = auth.uid());
+
+-- player_favorite_tournaments -------------------------------------------
+
+alter table public.player_favorite_tournaments enable row level security;
+
+drop policy if exists "wishlist read own" on public.player_favorite_tournaments;
+create policy "wishlist read own"
+  on public.player_favorite_tournaments
+  for select
+  using (player_id = public.current_player_id());
+
+drop policy if exists "wishlist insert own" on public.player_favorite_tournaments;
+create policy "wishlist insert own"
+  on public.player_favorite_tournaments
+  for insert
+  with check (player_id = public.current_player_id());
+
+drop policy if exists "wishlist delete own" on public.player_favorite_tournaments;
+create policy "wishlist delete own"
+  on public.player_favorite_tournaments
+  for delete
+  using (player_id = public.current_player_id());
+
+-- Anonymous callers get nothing on either table. Tournaments stay public and
+-- are deliberately untouched here.
+revoke all on public.player_favorite_tournaments from anon;
+revoke all on public.players from anon;


### PR DESCRIPTION
Closes the three open security bugs plus the a11y issue, and adds the database policies that were never version controlled.

## What changed

**Hardcoded credentials (#52)**
The issue named `app/tournaments/page.tsx`, which is actually clean. The committed project URL and anon JWT were in four other files, each building its own inline client instead of importing `lib/supabase.ts`:

- `app/page.tsx`
- `app/sitemap.ts`
- `app/country/[code]/page.tsx`
- `app/tournaments/[id]/page.tsx`

All four now use the shared client, which already throws on missing env vars. A `secret-scan` workflow was added so this cannot silently return.

> **The exposed anon key is still valid.** It is in git history, so removing it from HEAD does not revoke it. It needs rotating in the Supabase dashboard.

**Wishlist IDOR (#54)**
`GET`, `POST` and `DELETE` all took `player_id` from the query string or body and passed it to Supabase unchecked, so any caller could read or mutate any player's wishlist by guessing an id. Handlers now resolve the caller via `getAuthenticatedPlayer()`, which verifies the bearer token, maps the auth user to their `players` row, and returns a token-scoped client. A client-supplied `player_id` is ignored.

**RLS policies**
`docs/ARCHITECTURE.md` referenced `supabase/migrations/`, but the directory did not exist, so no policy was ever under version control. That is the root cause here: the browser still queries `player_favorite_tournaments` directly with the anon key from `app/player/wishlist/page.tsx`, so the route fix alone is not enough. Adds RLS on `players` and `player_favorite_tournaments` scoped through a `current_player_id()` helper.

**Param validation and map truncation (#56)**
Two distinct problems. `/api/tournaments` ran `parseInt` and passed `undefined` on `NaN`, so `?limit=abc` silently returned defaults as though the input were honoured; both params now 400 unless positive integers. Separately, the home page used a bare `.limit(1000)` while the dataset is past 1600 upcoming tournaments, so the map was quietly dropping several hundred markers. Replaced with a paged fetch.

**Result announcement (#61)**
The live region existed but only announced pagination state. It now leads with the match count and echoes the search term.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- `next build` generates all 134 pages including the sitemap and 113 country pages
- `playwright test` passing

## Not done here

- **Rotating the anon key** requires dashboard access.
- **Applying the migration.** It is committed but not applied. `supabase/README.md` lists the steps to verify against a branch project first, since enabling RLS denies everything not explicitly permitted.