### PR TITLE
ci: skip e2e on Dependabot pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,11 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e:
+    # GitHub does not expose repository secrets to Dependabot-triggered runs,
+    # so the Supabase vars below are empty there and the dev server refuses to
+    # boot. Dependency bumps are still gated by lint and build in ci.yml, and
+    # e2e runs against main once the bump merges.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
All five open Dependabot PRs (#84-88) fail e2e with:

```
Error: Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set
```

This is not a signal about any of the bumps. GitHub deliberately withholds repository secrets from Dependabot-triggered runs, so `secrets.SUPABASE_URL` and `secrets.SUPABASE_ANON_KEY` resolve empty and the dev server refuses to boot before Playwright can connect.

Left alone, every future dependency PR looks broken.

Dependency bumps remain gated by lint and build in `ci.yml`, and e2e runs against `main` the moment a bump merges.

Not adding the credentials to the Dependabot secrets scope right now, since the anon key involved is pending rotation.