### PR TITLE
feat: scrape tournament rating restrictions into min_rating/max_rating

### DIFF
--- a/app/tournaments/[id]/TournamentDetailClient.tsx
+++ b/app/tournaments/[id]/TournamentDetailClient.tsx
@@ -16,6 +16,8 @@ interface Tournament {
   country_code?: string;
   rounds?: number;
   fide_rated?: boolean;
+  min_rating?: number | null;
+  max_rating?: number | null;
   category?: string;
   format?: string;
   organizer_name?: string;
@@ -55,6 +57,13 @@ function InfoRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function ratingDisplay(min: number | null | undefined, max: number | null | undefined): string {
+  if (min != null && max != null) return `${min}–${max}`;
+  if (max != null) return `U${max}`;
+  if (min != null) return `Over ${min}`;
+  return "";
+}
+
 export default function TournamentDetailClient({ tournament }: Props) {
   if (!tournament) {
     return (
@@ -92,6 +101,7 @@ export default function TournamentDetailClient({ tournament }: Props) {
                 <InfoRow label="Format" value={tournament.format || ""} />
                 <InfoRow label="Category" value={tournament.category || ""} />
                 <InfoRow label="FIDE Rated" value={tournament.fide_rated ? "Yes" : "No"} />
+                <InfoRow label="Rating" value={ratingDisplay(tournament.min_rating, tournament.max_rating)} />
                 <InfoRow label="Source" value={tournament.source || ""} />
               </tbody>
             </table>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -48,6 +48,8 @@ export type Tournament = {
   pdf: string
   prize_pool: string
   fide_rated: boolean
+  min_rating?: number | null
+  max_rating?: number | null
   description: string
   venue_name: string
   venue_address: string

--- a/lib/tournaments.ts
+++ b/lib/tournaments.ts
@@ -19,6 +19,8 @@ export interface TournamentListItem {
   country_code?: string;
   category?: string;
   fide_rated?: boolean;
+  min_rating?: number | null;
+  max_rating?: number | null;
   lat?: number;
   lng?: number;
   source_url?: string;
@@ -52,6 +54,8 @@ const TOURNAMENT_SELECT_FIELDS = `
   country_code,
   category,
   fide_rated,
+  min_rating,
+  max_rating,
   lat,
   lng,
   source_url,

--- a/scripts/scrape.ts
+++ b/scripts/scrape.ts
@@ -50,6 +50,8 @@ interface ScrapedTournament {
   external_link: string | null;
   lat: number | null;
   lng: number | null;
+  min_rating: number | null;
+  max_rating: number | null;
 }
 
 // ========== GEOCODING ==========
@@ -171,6 +173,45 @@ function detectFideRated(name: string): boolean {
   // "ELO" as a standalone word (not inside another word)
   if (/\belo\b/.test(n)) return true;
   return false;
+}
+
+// ========== RATING RESTRICTION DETECTION ==========
+// Parses rating restrictions out of tournament names, e.g. "Open U1600",
+// "Under 1600", "1400-1800", "Elo < 1600". Returns { min_rating, max_rating }
+// when parseable, 'unparseable' when restriction-like text is present but
+// unrecognised (the caller logs it so it is not silently dropped), or null
+// when no restriction is stated.
+function parseRatingRestriction(
+  text: string
+): { min_rating: number | null; max_rating: number | null } | 'unparseable' | null {
+  const t = (text || '').trim();
+  if (!t) return null;
+
+  // Range: "1400-1800", "1400 – 1800", "1400 to 1800"
+  const range = t.match(/(\d{3,4})\s*(?:-|–|—|to)\s*(\d{3,4})/i);
+  if (range) {
+    return {
+      min_rating: parseInt(range[1], 10),
+      max_rating: parseInt(range[2], 10),
+    };
+  }
+
+  // Upper bound: "U1600", "U-1600", "Under 1600", "Below 1600", "Elo < 1600", "<1600"
+  const upper = t.match(/(?:^|[^a-z])(?:u\s*-?\s*|under\s*|below\s*|(?:elo\s*)?[<]\s*)(\d{3,4})\b/i);
+  if (upper) return { min_rating: null, max_rating: parseInt(upper[1], 10) };
+
+  // Lower bound: "Over 1800", ">1800", "1800+"
+  const lower = t.match(/(?:^|[^a-z])(?:over\s*|(?:elo\s*)?[>]\s*)(\d{3,4})\b|(\d{3,4})\s*\+/i);
+  if (lower) return { min_rating: parseInt(lower[1] || lower[2], 10), max_rating: null };
+
+  // Restriction-like text present but unrecognised — surface it instead of
+  // silently dropping it. Keyword must sit near a 3-4 digit number so plain
+  // names like "FIDE Rated 2025" are not mistaken for restrictions.
+  if (/\b(?:u\s*-?\s*\d|under\b|below\b|over\b|elo\b|rating\s*limit|[<>])[^0-9]{0,12}\d{3,4}/i.test(t)) {
+    return 'unparseable';
+  }
+
+  return null;
 }
 
 // ========== COUNTRY CODES ==========
@@ -296,6 +337,16 @@ async function scrapeTournament(browser: Browser, url: string): Promise<ScrapedT
     const idMatch = url.match(/tnr(\d+)/);
     if (!idMatch) return null;
 
+    const rating = parseRatingRestriction(data.name);
+    if (rating === 'unparseable') {
+      await logScraperFailure(
+        `ratingRestriction:${url}`,
+        `Unrecognised rating restriction in tournament name: "${data.name}"`
+      );
+    }
+    const min_rating = rating === 'unparseable' || rating === null ? null : rating.min_rating;
+    const max_rating = rating === 'unparseable' || rating === null ? null : rating.max_rating;
+
     const countryCode = getCountryCode(data.federation);
     const country = getCountryName(data.federation);
     let city = data.location || country;
@@ -315,7 +366,9 @@ async function scrapeTournament(browser: Browser, url: string): Promise<ScrapedT
       source_url: url.split('&turdet')[0],
       external_link: data.externalLink || null,
       lat: null,
-      lng: null
+      lng: null,
+      min_rating,
+      max_rating
     };
   } catch (err) {
     await logScraperFailure(`scrapeTournament:${url}`, errorMessage(err));
@@ -444,6 +497,8 @@ async function pushTournaments(tournaments: ScrapedTournament[]): Promise<number
       category: detectCategory(t.name),
       format: 'Swiss',
       fide_rated: detectFideRated(t.name),
+      min_rating: t.min_rating,
+      max_rating: t.max_rating,
       scraped_at: new Date().toISOString()
     }, { onConflict: 'id' });
     if (!error) {

--- a/supabase/migrations/20260818120000_rating_restrictions.sql
+++ b/supabase/migrations/20260818120000_rating_restrictions.sql
@@ -1,0 +1,11 @@
+-- Add nullable rating restriction columns to tournaments.
+--
+-- The Chess-Results scraper (scripts/scrape.ts) parses rating restrictions
+-- out of tournament names — "U1600", "Under 1600", "1400-1800", "Elo < 1600"
+-- — and stores the bounds here. Nullable: most tournaments state no
+-- restriction, and unrecognised restriction text is logged rather than
+-- guessed at.
+
+alter table public.tournaments
+  add column if not exists min_rating integer,
+  add column if not exists max_rating integer;


### PR DESCRIPTION
﻿Closes #90

Scrapes tournament rating restrictions into new min_rating/max_rating columns on 	ournaments.

- scripts/scrape.ts: parse rating restriction values per source and write them alongside existing rows
- DB migration 20260818120000_rating_restrictions.sql adds the two columns
- lib/supabase.ts + lib/tournaments.ts: include the new fields in insert/select types
- pp/tournaments/[id]/TournamentDetailClient.tsx: show the rating range on the detail page

Verification: typecheck, lint, build all pass.
