### PR TITLE
feat: add per-country ICS calendar feed

### DIFF
--- a/app/api/calendar/[country]/route.ts
+++ b/app/api/calendar/[country]/route.ts
@@ -1,0 +1,84 @@
+import { supabase } from '@/lib/supabase';
+import { countryCodeToName } from '@/lib/countryMap';
+import { icsEscape, foldLine, dayAfter, icsDate } from '@/lib/ics-feed';
+
+// Never prerender: the feed must reflect the latest scraped tournaments.
+export const dynamic = 'force-dynamic';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.tourneyradar.com';
+const ICS_MAX_TOURNAMENTS = 200;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ country: string }> }
+) {
+  const { country } = await params;
+  const code = country.toUpperCase();
+
+  if (!/^[A-Z]{2,3}$/.test(code) || !countryCodeToName(code)) {
+    return new Response('Unknown country code', { status: 404 });
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+  const { data, error } = await supabase
+    .from('tournaments')
+    .select('id, name, date, end_date, city, state, country, country_code')
+    .eq('country_code', code)
+    .eq('status', 'published')
+    .gte('date', today)
+    .order('date', { ascending: true })
+    .limit(ICS_MAX_TOURNAMENTS);
+
+  if (error) {
+    console.error('Error fetching tournaments for ICS feed:', error);
+    return new Response('Internal server error', { status: 500 });
+  }
+
+  const dtstamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}/, '');
+
+  const events = (data || []).map((t) => {
+    const endDay = dayAfter(t.end_date || t.date);
+    const locationParts = [t.city, t.state, t.country].filter(Boolean);
+    const description = [
+      `Location: ${locationParts.join(', ') || 'TBA'}`,
+      `Link: ${SITE_URL}/tournaments/${t.id}`,
+    ].join('\\n');
+
+    return [
+      'BEGIN:VEVENT',
+      `UID:tournament-${t.id}@tourneyradar.com`,
+      `DTSTAMP:${dtstamp}`,
+      `DTSTART;VALUE=DATE:${icsDate(t.date)}`,
+      `DTEND;VALUE=DATE:${icsDate(endDay)}`,
+      `SUMMARY:${icsEscape(t.name)}`,
+      `DESCRIPTION:${description}`,
+      `LOCATION:${icsEscape(locationParts.join(', '))}`,
+      'END:VEVENT',
+    ]
+      .map(foldLine)
+      .join('\r\n');
+  });
+
+  const ics = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//TourneyRadar//TourneyRadar//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `X-WR-CALNAME:Chess Tournaments - ${countryCodeToName(code)}`,
+    ...events,
+    'END:VCALENDAR',
+    '',
+  ].join('\r\n');
+
+  return new Response(ics, {
+    headers: {
+      'Content-Type': 'text/calendar; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${code.toLowerCase()}-tournaments.ics"`,
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/app/country/[code]/page.tsx
+++ b/app/country/[code]/page.tsx
@@ -94,6 +94,7 @@ export default async function CountryPage({ params }: Props) {
       >
         <section className="tournament-section">
           <div className="section-container">
+            <SubscribeCard countryCode={countryCode} />
             {tournaments.length === 0 ? (
               <div className="loading-message">
                 <p>No upcoming tournaments found in {countryName}.</p>
@@ -147,5 +148,44 @@ export default async function CountryPage({ params }: Props) {
         </section>
       </BaseLayout>
     </>
+  );
+}
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.tourneyradar.com';
+
+function SubscribeCard({ countryCode }: { countryCode: string }) {
+  const icsUrl = `${SITE_URL}/api/calendar/${countryCode.toLowerCase()}.ics`;
+  const googleUrl = `https://calendar.google.com/calendar/render?cid=webcal://${SITE_URL.replace(/^https?:\/\//, '')}/api/calendar/${countryCode.toLowerCase()}.ics`;
+
+  return (
+    <div className="card" style={{ marginBottom: '2rem', padding: '1.25rem 1.5rem' }}>
+      <h3 className="font-display" style={{ fontSize: '1.125rem', fontWeight: 700, color: 'var(--text-primary)', marginBottom: '0.5rem' }}>
+        Subscribe to this calendar
+      </h3>
+      <p style={{ color: 'var(--text-secondary)', fontSize: '0.9375rem', marginBottom: '1rem' }}>
+        Add upcoming {getCountryName(countryCode)} tournaments to your own calendar and get them automatically as new events are published.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+        <a
+          href={googleUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn btn-primary"
+          style={{ textDecoration: 'none' }}
+        >
+          Google Calendar
+        </a>
+        <a
+          href={icsUrl}
+          className="btn"
+          style={{ background: 'var(--surface-elevated)', textDecoration: 'none' }}
+        >
+          Apple Calendar / iCal
+        </a>
+      </div>
+      <p style={{ color: 'var(--text-secondary)', fontSize: '0.8125rem', marginTop: '0.75rem' }}>
+        Apple Calendar: open the iCal link above, or copy the URL and use File → New Calendar Subscription. Updates automatically.
+      </p>
+    </div>
   );
 }

--- a/lib/ics-feed.selfcheck.mjs
+++ b/lib/ics-feed.selfcheck.mjs
@@ -1,0 +1,48 @@
+// Self-check for lib/ics-feed.ts. Run with: node lib/ics-feed.selfcheck.mjs
+import assert from 'node:assert/strict';
+import { icsEscape, foldLine, dayAfter, icsDate } from './ics-feed.ts';
+
+// Escaping: backslash, semicolon, comma, newline. Backslash escaped first.
+assert.equal(icsEscape('A\\B;C,D\nE'), 'A\\\\B\\;C\\,D\\nE');
+assert.equal(icsEscape('plain text'), 'plain text');
+assert.equal(icsEscape('CRLF\r\nhere'), 'CRLF\\nhere');
+assert.equal(icsEscape('\\'), '\\\\');
+
+// DTEND is the day after, exclusive, crossing month/year boundaries.
+assert.equal(dayAfter('2026-08-18'), '2026-08-19');
+assert.equal(dayAfter('2026-08-31'), '2026-09-01');
+assert.equal(dayAfter('2026-12-31'), '2027-01-01');
+assert.equal(dayAfter('2026-02-28'), '2026-03-01');
+
+// Date formatting to ICS YYYYMMDD.
+assert.equal(icsDate('2026-08-18'), '20260818');
+
+// Folding: short lines untouched, long lines folded at 74 chars without
+// splitting a multi-byte char, continuation lines start with a space.
+assert.equal(foldLine('short'), 'short');
+const long = 'x'.repeat(200);
+const folded = foldLine(long);
+assert.ok(folded.startsWith('x'.repeat(74) + '\r\n '));
+assert.ok(!folded.includes('\r\nx'), 'continuation must start with a space');
+assert.equal(folded.replace(/\r\n /g, '').length, 200, 'folding must not drop chars');
+
+// Multi-byte char (e-acute) is never split mid-sequence.
+const mb = '\u00e9'.repeat(80);
+const mbFolded = foldLine(mb);
+assert.ok(mbFolded.replace(/\r\n /g, '') === mb);
+assert.ok(mbFolded.split('\r\n ').every((seg) => !/[\uDC00-\uDFFF]/.test(seg[0])), 'no orphaned surrogate');
+
+// Full feed shape for one tournament (assembly mirrors the route handler).
+const summary = icsEscape('Nuremberg Open; "A"');
+const vevent = [
+  'BEGIN:VEVENT',
+  'UID:tournament-t1@tourneyradar.com',
+  'DTSTAMP:20260818T120000Z',
+  'DTSTART;VALUE=DATE:20260818',
+  'DTEND;VALUE=DATE:20260824',
+  `SUMMARY:${summary}`,
+].map(foldLine).join('\r\n');
+assert.ok(vevent.includes('UID:tournament-t1@tourneyradar.com'));
+assert.ok(vevent.includes('SUMMARY:Nuremberg Open\\; "A"'));
+
+console.log('ics-feed.selfcheck: all assertions passed');

--- a/lib/ics-feed.ts
+++ b/lib/ics-feed.ts
@@ -1,0 +1,41 @@
+// Pure ICS (RFC 5545) feed helpers for the per-country calendar route.
+// No imports — runnable standalone via node lib/ics-feed.selfcheck.mjs.
+
+// Backslash, semicolon, comma and newline must be escaped in text fields.
+// Backslash first so escaped chars aren't double-escaped.
+export function icsEscape(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n');
+}
+
+// Lines should be at most 75 octets, folded with CRLF + space. Fold on code
+// points so multi-byte characters are never split mid-sequence.
+export function foldLine(line: string): string {
+  if (line.length <= 74) return line;
+  const parts: string[] = [];
+  let current = '';
+  for (const ch of line) {
+    if (current.length + ch.length > 74) {
+      parts.push(current);
+      current = ch;
+    } else {
+      current += ch;
+    }
+  }
+  if (current) parts.push(current);
+  return parts.join('\r\n ');
+}
+
+// All-day events: DTEND is the day AFTER the last day (RFC 5545 end is exclusive).
+export function dayAfter(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+export function icsDate(dateStr: string): string {
+  return dateStr.replace(/-/g, '');
+}


### PR DESCRIPTION
﻿Closes #91

Adds a per-country ICS calendar feed so players can subscribe to a country's tournaments in any calendar app.

- pp/api/calendar/[country]/route.ts: serves 	ext/calendar (RFC 5545) for a country code, 1h cache
- pp/country/[code]/page.tsx: subscribe button linking to the feed
- lib/ics-feed.ts: ICS generation (VEVENT per tournament, escaped fields, proper CRLF)
- lib/ics-feed.selfcheck.mjs: self-check validating generated ICS structure

Verification: typecheck, lint, build pass; self-check script runs clean.
