### PR TITLE
feat: add location and notification-preference fields to players

### DIFF
--- a/lib/AuthContext.tsx
+++ b/lib/AuthContext.tsx
@@ -13,6 +13,11 @@ type Player = {
   phone?: string;
   fide_id?: string;
   rating?: number;
+  home_country_code?: string;
+  home_state?: string;
+  notify_frequency?: "off" | "weekly";
+  notify_categories?: string[];
+  min_fide_rated?: boolean;
 };
 
 

--- a/supabase/migrations/20260818120000_player_preference_fields.sql
+++ b/supabase/migrations/20260818120000_player_preference_fields.sql
@@ -1,0 +1,11 @@
+-- Location and notification-preference fields for the players table.
+--
+-- Foundation for the player onboarding flow. All columns are nullable so
+-- existing rows and the client-side registration insert (which sends none
+-- of these fields) keep working unchanged.
+
+alter table public.players add column if not exists home_country_code text;
+alter table public.players add column if not exists home_state text;
+alter table public.players add column if not exists notify_frequency text;
+alter table public.players add column if not exists notify_categories text[];
+alter table public.players add column if not exists min_fide_rated boolean;


### PR DESCRIPTION
﻿Closes #116

Adds location and notification-preference fields to players.

- DB migration 20260818120000_player_preference_fields.sql adds location and 
otify_* preference columns to players`n- lib/AuthContext.tsx: expose the new fields on the authed player

Verification: typecheck, lint, build pass.
