### PR TITLE
feat: post-signup onboarding flow

### DIFF
--- a/app/player/onboarding/page.tsx
+++ b/app/player/onboarding/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/lib/AuthContext";
+import { useThemePreference } from "@/lib/theme";
+import { listCountries } from "@/lib/countryMap";
+import MobileNavDrawer from "@/components/MobileNavDrawer";
+import SiteNav from "@/components/SiteNav";
+
+const CATEGORIES = ["Classical", "Rapid", "Blitz"];
+const TOTAL_STEPS = 3;
+const COUNTRIES = listCountries();
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  marginBottom: "0.5rem",
+  color: "var(--text-secondary)",
+};
+
+const secondaryBtnStyle: React.CSSProperties = {
+  background: "var(--surface-elevated)",
+  border: "2px solid var(--border)",
+  color: "var(--text-primary)",
+};
+
+export default function PlayerOnboardingPage() {
+  const router = useRouter();
+  const { user, userType, loading: authLoading, refreshAuth } = useAuth();
+  useThemePreference();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const [step, setStep] = useState(1);
+  const [homeCountry, setHomeCountry] = useState("");
+  const [categories, setCategories] = useState<string[]>([]);
+  const [fideOnly, setFideOnly] = useState(false);
+  const [frequency, setFrequency] = useState<"off" | "weekly">("off");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !user) router.push("/player/login");
+  }, [authLoading, user, router]);
+
+  const toggleCategory = (category: string) => {
+    setCategories((prev) =>
+      prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]
+    );
+  };
+
+  const finish = async () => {
+    if (!user) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const { error: updateError } = await supabase
+        .from("players")
+        .update({
+          home_country_code: homeCountry || null,
+          notify_categories: categories.length ? categories : null,
+          min_fide_rated: fideOnly,
+          notify_frequency: frequency,
+        })
+        .eq("id", user.id);
+
+      if (updateError) throw updateError;
+      await refreshAuth();
+      router.push("/player/dashboard");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't save your preferences");
+      setSaving(false);
+    }
+  };
+
+  const skip = () => router.push("/player/dashboard");
+
+  if (authLoading || !user || userType !== "player") {
+    return <div style={{ background: "var(--background)", minHeight: "100vh" }} />;
+  }
+
+  return (
+    <div style={{ background: "var(--background)", minHeight: "100vh" }}>
+      <MobileNavDrawer open={mobileMenuOpen} onClose={() => setMobileMenuOpen(false)} userType={null} showThemeToggle />
+
+      <section className="hero-bg" style={{ minHeight: "30vh", display: "flex", flexDirection: "column" }}>
+        <SiteNav onMenuClick={() => setMobileMenuOpen(true)} />
+
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: "2rem" }}>
+          <h1 className="hero-title font-display" style={{ textAlign: "center" }}>
+            Welcome, <span className="highlight">{user.name?.split(" ")[0] || "player"}</span>
+          </h1>
+        </div>
+      </section>
+
+      <section className="tournament-section">
+        <div className="section-container" style={{ maxWidth: "600px" }}>
+          <div className="card">
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
+              <span style={{ fontSize: "0.8125rem", fontWeight: 600, color: "var(--text-secondary)" }}>
+                Step {step} of {TOTAL_STEPS}
+              </span>
+              <button
+                type="button"
+                onClick={skip}
+                style={{ background: "none", border: "none", color: "var(--text-secondary)", fontSize: "0.8125rem", cursor: "pointer", textDecoration: "underline" }}
+              >
+                Skip for now
+              </button>
+            </div>
+
+            {error && (
+              <div style={{ padding: "1rem", background: "var(--error)", color: "white", borderRadius: "12px", marginBottom: "1.5rem" }}>
+                {error}
+              </div>
+            )}
+
+            {step === 1 && (
+              <>
+                <h2 className="font-display" style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "0.5rem", color: "var(--text-primary)" }}>
+                  Where are you based?
+                </h2>
+                <p style={{ color: "var(--text-secondary)", marginBottom: "1.5rem" }}>
+                  We&apos;ll use this to surface tournaments near you first.
+                </p>
+                <div style={{ marginBottom: "2rem" }}>
+                  <label style={labelStyle}>Home country</label>
+                  <select
+                    className="form-select"
+                    value={homeCountry}
+                    onChange={(e) => setHomeCountry(e.target.value)}
+                  >
+                    <option value="">Select a country</option>
+                    {COUNTRIES.map((c) => (
+                      <option key={c.code} value={c.code}>{c.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <button type="button" className="btn btn-primary" style={{ width: "100%" }} onClick={() => setStep(2)}>
+                  Next
+                </button>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <h2 className="font-display" style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "0.5rem", color: "var(--text-primary)" }}>
+                  What do you play?
+                </h2>
+                <p style={{ color: "var(--text-secondary)", marginBottom: "1.5rem" }}>
+                  Pick the categories you care about. You can select more than one.
+                </p>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginBottom: "1.5rem" }}>
+                  {CATEGORIES.map((category) => (
+                    <label key={category} style={{ display: "flex", alignItems: "center", gap: "0.625rem", cursor: "pointer", color: "var(--text-primary)" }}>
+                      <input
+                        type="checkbox"
+                        checked={categories.includes(category)}
+                        onChange={() => toggleCategory(category)}
+                      />
+                      {category}
+                    </label>
+                  ))}
+                </div>
+                <label style={{ display: "flex", alignItems: "center", gap: "0.625rem", cursor: "pointer", color: "var(--text-primary)", marginBottom: "2rem" }}>
+                  <input type="checkbox" checked={fideOnly} onChange={(e) => setFideOnly(e.target.checked)} />
+                  Only FIDE-rated tournaments
+                </label>
+                <div style={{ display: "flex", gap: "0.75rem" }}>
+                  <button type="button" className="btn" style={secondaryBtnStyle} onClick={() => setStep(1)}>
+                    Back
+                  </button>
+                  <button type="button" className="btn btn-primary" style={{ flex: 1 }} onClick={() => setStep(3)}>
+                    Next
+                  </button>
+                </div>
+              </>
+            )}
+
+            {step === 3 && (
+              <>
+                <h2 className="font-display" style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "0.5rem", color: "var(--text-primary)" }}>
+                  How often should we email you?
+                </h2>
+                <p style={{ color: "var(--text-secondary)", marginBottom: "1.5rem" }}>
+                  Matching tournaments in your area and categories. You can change this anytime.
+                </p>
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginBottom: "2rem" }}>
+                  <label style={{ display: "flex", alignItems: "center", gap: "0.625rem", cursor: "pointer", color: "var(--text-primary)" }}>
+                    <input type="radio" name="frequency" checked={frequency === "weekly"} onChange={() => setFrequency("weekly")} />
+                    Weekly digest
+                  </label>
+                  <label style={{ display: "flex", alignItems: "center", gap: "0.625rem", cursor: "pointer", color: "var(--text-primary)" }}>
+                    <input type="radio" name="frequency" checked={frequency === "off"} onChange={() => setFrequency("off")} />
+                    Don&apos;t email me
+                  </label>
+                </div>
+                <div style={{ display: "flex", gap: "0.75rem" }}>
+                  <button type="button" className="btn" style={secondaryBtnStyle} onClick={() => setStep(2)} disabled={saving}>
+                    Back
+                  </button>
+                  <button type="button" className="btn btn-primary" style={{ flex: 1, opacity: saving ? 0.6 : 1 }} onClick={finish} disabled={saving}>
+                    {saving ? "Saving..." : "Finish"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/player/register/page.tsx
+++ b/app/player/register/page.tsx
@@ -66,7 +66,7 @@ export default function PlayerRegisterPage() {
       posthog.capture("player_registered");
       setSuccess(true);
       setTimeout(() => {
-        router.push("/player/dashboard");
+        router.push("/player/onboarding");
       }, 2000);
     } catch (err: any) {
       setError(err.message || "Registration failed");
@@ -99,7 +99,7 @@ export default function PlayerRegisterPage() {
                   Registration Successful!
                 </h2>
                 <p style={{ color: "var(--text-secondary)" }}>
-                  Redirecting to your dashboard...
+                  Redirecting you to set up your preferences...
                 </p>
               </div>
             ) : (

--- a/lib/countryMap.ts
+++ b/lib/countryMap.ts
@@ -244,3 +244,14 @@ export function countryCodeToName(code: string): string | null {
   if (!code) return null;
   return CODE_TO_NAME[code.trim().toUpperCase()] ?? null;
 }
+
+/**
+ * All known countries as { code, name } pairs, sorted by name. Filters out
+ * the stray non-ISO 'AT_' entry kept above for a Swiss-vs-Austria note.
+ */
+export function listCountries(): { code: string; name: string }[] {
+  return Object.entries(CODE_TO_NAME)
+    .filter(([code]) => code.length === 2)
+    .map(([code, name]) => ({ code, name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## What does this PR do?

Adds a 3-step wizard immediately after signup: (1) home country, (2) category interest (Classical/Rapid/Blitz) + FIDE-rated-only preference, (3) notification frequency. Reuses `.form-input`/`.form-select` and the plain-`useState` pattern from `app/player/register/page.tsx`, and the country list already in `lib/countryMap.ts` (added a small `listCountries()` export rather than duplicating the list). Writes to the preference columns already added in `20260818120000_player_preference_fields.sql`. Register now redirects to `/player/onboarding` instead of straight to the dashboard; every step has a Skip-for-now link.

Closes #117

## Type of change

- [ ] Bug fix
- [ ] New scraper source
- [x] Feature / enhancement
- [ ] Refactor / cleanup

## For new scrapers

N/A — not a scraper change.

## Checklist

- [x] TypeScript compiles with no errors (`npm run build`)
- [x] No `any` types introduced
- [x] No credentials or secrets in the code